### PR TITLE
test: JwtAuthenticationFilter 단위 테스트 및 Ci 스크립트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ develop ]   # develop 대상으로 오는 PR에서만 실행
+  push:
+    branches: [ develop ]   # (선택) develop에 직접 push 되었을 때도 실행
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests with coverage (fail under 80%)
+        run: ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification --no-daemon
+
+      - name: Upload JaCoCo HTML report (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.example'
@@ -60,6 +61,32 @@ dependencies {
 	implementation 'software.amazon.awssdk:sts:2.25.48'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport, jacocoTestCoverageVerification
+}
+
+jacoco {
+	toolVersion = '0.8.12'
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			// 전체 라인 커버리지 기준
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.80
+			}
+		}
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,21 @@ jacocoTestReport {
 		xml.required = true
 		html.required = true
 	}
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, exclude: [
+							'com/example/blog/common/config/**',
+							'com/example/blog/common/enumerated/**',
+							'com/example/blog/common/exception/**',
+							'com/example/blog/common/logging/**',
+							'com/example/blog/common/utils/**'
+					])
+				})
+		)
+	}
 }
+
 
 jacocoTestCoverageVerification {
 	violationRules {
@@ -87,6 +101,13 @@ jacocoTestCoverageVerification {
 				value = 'COVEREDRATIO'
 				minimum = 0.80
 			}
+			excludes = [
+					'com/example/blog/common/config/**',
+					'com/example/blog/common/enumerated/**',
+					'com/example/blog/common/exception/**',
+					'com/example/blog/common/logging/**',
+					'com/example/blog/common/utils/**'
+			]
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,26 @@ jacoco {
 	toolVersion = '0.8.12'
 }
 
+def jacocoExcludes = [
+		'**/*Application*',
+		'com/example/blog/common/config/**',
+		'com/example/blog/common/enumerated/**',
+		'com/example/blog/common/exception/**',
+		'com/example/blog/common/logging/**',
+		'com/example/blog/common/utils/**',
+
+		'com/example/blog/auth/handler/**',
+		'com/example/blog/auth/oauth/**',
+		'com/example/blog/auth/user_details/**',
+
+		'com/example/blog/common/aws/s3/**', // 추후 추가
+		'com/example/blog/**/dto/**',
+		'com/example/blog/**/entity/**',
+
+		'**/*MapperImpl.class',
+		'**/Q*.class'
+]
+
 jacocoTestReport {
 	dependsOn test
 	reports {
@@ -79,35 +99,29 @@ jacocoTestReport {
 	afterEvaluate {
 		classDirectories.setFrom(
 				files(classDirectories.files.collect {
-					fileTree(dir: it, exclude: [
-							'com/example/blog/common/config/**',
-							'com/example/blog/common/enumerated/**',
-							'com/example/blog/common/exception/**',
-							'com/example/blog/common/logging/**',
-							'com/example/blog/common/utils/**'
-					])
+					fileTree(dir: it, exclude: jacocoExcludes)
 				})
 		)
 	}
 }
 
-
 jacocoTestCoverageVerification {
 	violationRules {
 		rule {
-			// 전체 라인 커버리지 기준
+			element = 'BUNDLE'
 			limit {
-				counter = 'LINE'
-				value = 'COVEREDRATIO'
-				minimum = 0.80
+				counter = 'INSTRUCTION'
+				value   = 'MISSEDRATIO'
+				maximum = 0.20
 			}
-			excludes = [
-					'com/example/blog/common/config/**',
-					'com/example/blog/common/enumerated/**',
-					'com/example/blog/common/exception/**',
-					'com/example/blog/common/logging/**',
-					'com/example/blog/common/utils/**'
-			]
 		}
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, exclude: jacocoExcludes)
+				})
+		)
 	}
 }

--- a/src/main/java/com/example/blog/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/blog/auth/jwt/JwtAuthenticationFilter.java
@@ -23,44 +23,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-//@Component
-//@RequiredArgsConstructor
-//public class JwtAuthenticationFilter extends OncePerRequestFilter {
-//
-//  private final MemberRepository memberRepository;
-//  private final JwtService jwtService;
-//  @Override
-//  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-//      FilterChain filterChain) throws ServletException, IOException {
-//    String token = extractTokenFromCookie(request, "ACCESS_TOKEN");
-//    if (token != null) {
-//      try {
-//        Claims claims = jwtService.parseToken(token);
-//        Long userId = Long.parseLong(claims.getSubject());
-//
-//        memberRepository.findById(userId).ifPresent(member -> {
-//          CustomUserDetails userDetails = new CustomUserDetails(member);
-//          UsernamePasswordAuthenticationToken auth =
-//              new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-//          SecurityContextHolder.getContext().setAuthentication(auth);
-//        });
-//      } catch (Exception e) {
-//        SecurityContextHolder.clearContext();
-//      }
-//    }
-//    filterChain.doFilter(request, response);
-//  }
-//
-//  private String extractTokenFromCookie(HttpServletRequest request, String name) {
-//    if (request.getCookies() == null) return null;
-//    return Arrays.stream(request.getCookies())
-//        .filter(c -> name.equals(c.getName()))
-//        .map(Cookie::getValue)
-//        .findFirst().orElse(null);
-//  }
-//
-//}
-
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {

--- a/src/main/java/com/example/blog/auth/jwt/JwtService.java
+++ b/src/main/java/com/example/blog/auth/jwt/JwtService.java
@@ -1,6 +1,6 @@
 package com.example.blog.auth.jwt;
 
-import com.example.blog.auth.blacklist.Blacklist;
+
 import com.example.blog.common.exception.AuthException;
 import com.example.blog.common.exception.ErrorCode;
 import com.example.blog.domain.member.entity.Member;
@@ -10,84 +10,11 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class JwtService {
-//
-//  @Value("${app.jwt.secret}")
-//  private String SECRET;
-//  private final long ACCESS_TOKEN_EXPIRATION = 3600000;
-//  private final long REFRESH_TOKEN_EXPIRATION = 1209600000;
-//  private final Blacklist blacklist;
-//
-//  public String generateAccessToken(Member member, String role){
-//    return Jwts.builder()
-//        .setSubject(String.valueOf(member.getId()))
-//        .claim("role", role)
-//        .claim("email", member.getEmail())
-//        .claim("name", member.getName())
-//        .setIssuedAt(new Date())
-//        .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
-//        .signWith(getSigningKey())
-//        .compact();
-//  }
-//
-//  public String generateRefreshToken(UUID userId) {
-//    return Jwts.builder()
-//        .setSubject(String.valueOf(userId))
-//        .setIssuedAt(new Date())
-//        .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
-//        .signWith(getSigningKey())
-//        .compact();
-//  }
-//
-//  public Claims parseToken(String token){
-//    return Jwts.parserBuilder()
-//        .setSigningKey(getSigningKey())
-//        .build()
-//        .parseClaimsJws(token)
-//        .getBody();
-//  }
-//
-//  public boolean validateToken(String token){
-//    try{
-//      Claims claims = parseToken(token  );
-//      Date expiration = claims.getExpiration();
-//      return expiration.after(new Date());
-//    } catch (Exception e){
-//      throw new AuthException(ErrorCode.INVALID_TOKEN_ERROR);
-//    }
-//  }
-//
-//  public void invalidateToken(String token){
-//    blacklist.addToBlackList(token, extractExpirationInstant(token));
-//  }
-//
-//  public Date extractExpiration(String token) {
-//    try {
-//      return parseToken(token).getExpiration();
-//    } catch (ExpiredJwtException e) {
-//      return e.getClaims().getExpiration();
-//    }
-//  }
-//
-//  public Instant extractExpirationInstant(String token) {
-//    return extractExpiration(token).toInstant();
-//  }
-//  private Key getSigningKey(){
-//    return  Keys.hmacShaKeyFor(SECRET.getBytes());
-//  }
-//}
-//
-//
-//
 
 /**
  * 책임: JWT 생성/파싱/서명검증(만료 포함) - 블랙리스트 등 운영정책은 관여하지 않음

--- a/src/main/java/com/example/blog/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/blog/auth/service/AuthServiceImpl.java
@@ -30,140 +30,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-//
-//
-//@Service
-//@RequiredArgsConstructor
-//public class AuthServiceImpl implements AuthService{
-//
-//  private final MemberRepository memberRepository;
-//  private final MemberMapper memberMapper;
-//  private final PasswordEncoder passwordEncoder;
-//  private final JwtService jwtService;
-//  private final S3Service s3Service;
-//  private final RefreshTokenRepository refreshTokenRepository;
-//  private static final String ACCESS_COOKIE = "ACCESS_TOKEN";
-//  private static final String REFRESH_COOKIE = "REFRESH_TOKEN";
-//
-//  @Value("${app.cookies.secure:true}")
-//  private boolean cookieSecure;
-//  private String sameSite() { return cookieSecure ? "None" : "Lax"; }
-//  @Override
-//  public MemberResponseDto register(HttpServletResponse response, RegisterRequestDTO registerDto) {
-//
-//    if(!Objects.equals(registerDto.password(), registerDto.checkPassword())){
-//      throw new AuthException(ErrorCode.REGISTER_EXCEPTION);
-//    }
-//
-//    Member member = memberMapper.toEntity(registerDto);
-//    member.updatePassword(passwordEncoder.encode(registerDto.password()));
-//    member.updateStatus(MemberStatus.ACTIVE);
-//    member.updateRole(MemberRole.USER);
-//    Member savedMember = memberRepository.save(member);
-//
-//    return memberMapper.toResponseDto(savedMember);
-//  }
-//
-//  @Override
-//  public void signOut(HttpServletRequest req, HttpServletResponse res, PrincipalMember member) {
-//    // 1) 토큰 추출
-//    String accessToken = extractAccessTokenFromHeader(req).orElse(null);
-//    String refreshToken = extractCookie(req, REFRESH_COOKIE).orElse(null);
-//
-//    // 2) 서버 측 무효화(블랙리스트 등) – 존재할 때만
-//    if (refreshToken != null) {
-//      jwtService.invalidateToken(refreshToken);
-//    }
-//    if (accessToken != null) {
-//      jwtService.invalidateToken(accessToken);
-//    }
-//    refreshTokenRepository.deleteById(member.getMember().getId());
-//
-//    CookieUtils.clearAllRefreshCookies(res, true, sameSite());
-//
-//    res.setStatus(HttpServletResponse.SC_OK);
-//  }
-//
-//
-//  @Override
-//  public Map<String, Object>  refresh(HttpServletRequest request, HttpServletResponse response) {
-//// 1) 다중 RT 쿠키 중 "유효 + 저장소 매칭 + 최신(iat)" 선택
-//
-//    String refreshToken = resolveValidRefreshToken(request)
-//        .orElseThrow(() -> new AuthException(ErrorCode.INVALID_TOKEN_ERROR));
-//
-//    UUID userId = UUID.fromString(jwtService.parseToken(refreshToken).getSubject());
-//    RefreshToken stored = refreshTokenRepository.findById(userId)
-//        .orElseThrow(() -> new AuthException(ErrorCode.INVALID_TOKEN_ERROR));
-//    if (!stored.getToken().equals(refreshToken)) {
-//      throw new AuthException(ErrorCode.INVALID_TOKEN_ERROR);
-//    }
-//
-//    // 2) 새 Access
-//    Member member = memberRepository.findById(userId)
-//        .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
-//    String newAccessToken = jwtService.generateAccessToken(member, member.getRole().name());
-//
-//    // 3) ★ 회전(rotate) + 전량 삭제 후 단일 세팅
-//    String newRefresh = jwtService.generateRefreshToken(userId);
-//    stored.updateToken(newRefresh);
-//    refreshTokenRepository.save(stored);
-//
-//    clearAllRefreshCookies(response, cookieSecure, sameSite());
-//    setRefreshCookie(response, newRefresh, cookieSecure, sameSite());
-//
-//    return Map.of("accessToken", newAccessToken, "expiresIn", 900);
-//  }
-//
-//
-//  // ===== Helpers =====
-//  private Optional<String> extractCookie(HttpServletRequest req, String name) {
-//    Cookie[] cookies = req.getCookies();
-//    if (cookies == null) return Optional.empty();
-//    for (Cookie c : cookies) {
-//      if (name.equals(c.getName())) {
-//        return Optional.ofNullable(c.getValue());
-//      }
-//    }
-//    return Optional.empty();
-//  }
-//
-//  private Optional<String> extractAccessTokenFromHeader(HttpServletRequest req) {
-//    String authHeader = req.getHeader("Authorization");
-//    if (authHeader == null) return Optional.empty();
-//    final String prefix = "Bearer ";
-//    if (authHeader.startsWith(prefix) && authHeader.length() > prefix.length()) {
-//      return Optional.of(authHeader.substring(prefix.length()));
-//    }
-//    return Optional.empty();
-//  }
-//
-//  private Optional<String> resolveValidRefreshToken(HttpServletRequest request) {
-//    Cookie[] cookies = request.getCookies();
-//    if (cookies == null) return Optional.empty();
-//
-//    return Arrays.stream(cookies)
-//        .filter(c -> REFRESH_COOKIE.equals(c.getName()))
-//        .map(Cookie::getValue)
-//        .filter(jwtService::validateToken)
-//        .sorted((a, b) -> {
-//          Date ia = jwtService.parseToken(a).getIssuedAt();
-//          Date ib = jwtService.parseToken(b).getIssuedAt();
-//          long la = ia != null ? ia.getTime() : 0L;
-//          long lb = ib != null ? ib.getTime() : 0L;
-//          return Long.compare(lb, la); // 최신 우선
-//        })
-//        .filter(t -> {
-//          UUID uid = UUID.fromString(jwtService.parseToken(t).getSubject());
-//          return refreshTokenRepository.findById(uid)
-//              .map(RefreshToken::getToken)
-//              .filter(stored -> stored.equals(t))
-//              .isPresent();
-//        })
-//        .findFirst();
-//  }
-//}
-
 
 
 /** 책임: 회원가입/로그아웃/리프레시 등 인증 유스케이스 오케스트레이션 */
@@ -205,6 +71,7 @@ public class AuthServiceImpl implements AuthService {
   public void signOut(HttpServletRequest req, HttpServletResponse res, PrincipalMember pm) {
     extractAccessTokenFromHeader(req).ifPresent(t ->
         invalidationService.invalidate(t, jwtService.extractExpiration(t).toInstant()));
+
     extractCookie(req, REFRESH_COOKIE).ifPresent(t ->
         invalidationService.invalidate(t, jwtService.extractExpiration(t).toInstant()));
     refreshTokenRepository.deleteById(pm.getMember().getId());
@@ -218,8 +85,8 @@ public class AuthServiceImpl implements AuthService {
     String rt = resolveValidRefreshToken(req)
         .orElseThrow(() -> new AuthException(ErrorCode.INVALID_TOKEN_ERROR));
 
-    jwtService.assertValid(rt);
-    invalidationService.assertNotInvalid(rt);
+//    jwtService.assertValid(rt);
+//    invalidationService.assertNotInvalid(rt);
 
     UUID uid = UUID.fromString(jwtService.parse(rt).getSubject());
 

--- a/src/main/java/com/example/blog/common/config/AppConfig.java
+++ b/src/main/java/com/example/blog/common/config/AppConfig.java
@@ -1,10 +1,8 @@
 package com.example.blog.common.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-//@PropertySource("classpath:application-env.properties")
 public class AppConfig {
 
 }

--- a/src/main/java/com/example/blog/common/config/AppConfig.java
+++ b/src/main/java/com/example/blog/common/config/AppConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource("classpath:application-env.properties")
+//@PropertySource("classpath:application-env.properties")
 public class AppConfig {
 
 }

--- a/src/main/java/com/example/blog/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/blog/domain/member/service/MemberServiceImpl.java
@@ -31,9 +31,11 @@ public class MemberServiceImpl implements MemberService {
   public Member updateMember(UpdateMemberRequestDto request, PrincipalMember member) {
 
     Member foundMember = findOrThrowMember(member.getMember().getId());
-    // validatePassword(request.password(), foundMember.getPassword());
 
-    if(foundMember.getProvider() == null) foundMember.updatePassword(encoder.encode(request.password()));
+    if(foundMember.getProvider() == null){
+      validatePassword(request.password(), foundMember.getPassword());
+      foundMember.updatePassword(encoder.encode(request.password()));
+    }
 
     foundMember.updateNickname(request.nickname());
     profilePolicy.validateOwnedKey(request.s3Key(), foundMember.getId());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,8 @@ app:
     secure: true
   jwt:
     secret: ${JWT_SECRET}
+    access-exp-ms: 3600000
+    refresh-exp-ms: 1209600000
   client-url: "http://localhost:3000"
 
 custom:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  config:
-    import: application-env.properties
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/test/java/com/example/blog/BlogApplicationTests.java
+++ b/src/test/java/com/example/blog/BlogApplicationTests.java
@@ -3,8 +3,10 @@ package com.example.blog;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BlogApplicationTests {
 
 	@Test

--- a/src/test/java/com/example/blog/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/blog/auth/controller/AuthControllerTest.java
@@ -1,0 +1,76 @@
+package com.example.blog.auth.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.example.blog.auth.dto.RegisterRequestDTO;
+import com.example.blog.auth.service.AuthService;
+import com.example.blog.domain.member.dto.MemberResponseDto;
+import com.example.blog.domain.member.entity.MemberRole;
+import com.example.blog.common.enumerated.MemberStatus;
+import com.example.blog.domain.refresh_token.RefreshTokenRepository;
+import com.example.blog.mapper.MemberMapper;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AuthControllerStandaloneTest {
+
+  @Mock AuthService authService;
+  @Mock RefreshTokenRepository refreshTokenRepository;
+  @Mock MemberMapper memberMapper;
+
+  @InjectMocks AuthController authController;
+
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void 초기화() {
+    MockitoAnnotations.openMocks(this);
+    mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
+  }
+
+  @Test
+  @DisplayName("회원가입 성공 시 200")
+  void 회원가입_성공시_200() throws Exception {
+    MemberResponseDto dummy = new MemberResponseDto(
+        UUID.randomUUID(), Instant.now(), null, "email@test.com", "nick", null, MemberStatus.ACTIVE, null, "name", MemberRole.USER
+    );
+    given(authService.register(any(), any(RegisterRequestDTO.class))).willReturn(dummy);
+
+    String body = """
+      {"email":"email@test.com","password":"pw","nickname":"nick","name":"name"}
+      """;
+
+    mockMvc.perform(post("/api/auth/register").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isOk());
+
+    verify(authService).register(any(), any(RegisterRequestDTO.class));
+  }
+
+  @Test
+  @DisplayName("refresh 성공 시 200과 토큰 반환")
+  void refresh_성공시_200() throws Exception {
+    given(authService.refresh(any(), any())).willReturn(Map.of("accessToken","acc","refreshToken","ref"));
+
+    mockMvc.perform(post("/api/auth/refresh"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("acc"))
+        .andExpect(jsonPath("$.refreshToken").value("ref"));
+
+    verify(authService).refresh(any(), any());
+  }
+
+  @Test
+  @DisplayName("refresh 실패 시 401")
+  void refresh_실패시_401() throws Exception {
+    given(authService.refresh(any(), any())).willThrow(new RuntimeException("boom"));
+    mockMvc.perform(post("/api/auth/refresh")).andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/java/com/example/blog/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/blog/auth/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,142 @@
+package com.example.blog.auth.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+import com.example.blog.auth.jwt.JwtAuthenticationFilter;
+import com.example.blog.auth.jwt.JwtService;
+import com.example.blog.common.enumerated.MemberStatus;
+import com.example.blog.common.enumerated.Provider;
+import com.example.blog.domain.member.entity.Member;
+import com.example.blog.domain.member.entity.MemberRole;
+import com.example.blog.domain.member.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtAuthenticationFilterTest {
+
+  @Mock
+  MemberRepository memberRepository;
+  @Mock
+  JwtService jwtService;
+  @Mock
+  FilterChain chain;
+  @InjectMocks
+  JwtAuthenticationFilter jwtFilter;
+
+  @BeforeEach
+  void setUp(){
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("Authorization 헤더가 없다면 인증을 시도하지 않는다")
+  void 헤더_없을시_인증을_시도하지_않는다() throws ServletException, IOException {
+    //given
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    MockHttpServletResponse res = new MockHttpServletResponse();
+
+    // when
+    jwtFilter.doFilterInternal(req, res, chain);
+
+    // then
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    then(chain).should().doFilter(req, res);
+    then(jwtService).shouldHaveNoInteractions();
+    then(memberRepository).shouldHaveNoInteractions();
+  }
+
+  @Test
+  @DisplayName("유효한 토큰과 존재하는 회원이면 SecurityContext에 인증을 설정한다")
+  void 유효토큰_회원존재_인증성공() throws ServletException, IOException {
+    //given
+    UUID userId = UUID.randomUUID();
+    String token = "token.token.token";
+    Member m = new Member("test", "test", "test", Provider.GOOGLE, "testid", MemberStatus.ACTIVE, null, "test", MemberRole.USER);
+    Claims claims = mock(Claims.class);
+
+    given(claims.getSubject()).willReturn(userId.toString());
+    given(jwtService.parse(token)).willReturn(claims);
+    given(memberRepository.findById(userId)).willReturn(Optional.of(m));
+
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    MockHttpServletResponse res = new MockHttpServletResponse();
+
+    req.addHeader("Authorization", "Bearer " + token);
+
+    //when
+    jwtFilter.doFilterInternal(req, res, chain);
+
+    //then
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("유효한 토큰이지만 회원이 존재하지 않으면 인증을 설정하지 않는다")
+  void 유효토큰_회원없음_미인증() throws ServletException, IOException {
+    // given
+    UUID userId = UUID.randomUUID();
+    String token = "valid.jwt.token";
+
+    Claims claims = mock(Claims.class);
+    given(claims.getSubject()).willReturn(userId.toString());
+    given(jwtService.parse(token)).willReturn(claims);
+    given(memberRepository.findById(userId)).willReturn(Optional.empty());
+
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.addHeader("Authorization", "Bearer " + token);
+    MockHttpServletResponse res = new MockHttpServletResponse();
+
+    // when
+    jwtFilter.doFilterInternal(req, res, chain);
+
+    // then
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    then(jwtService).should().parse(token);
+    then(memberRepository).should().findById(userId);
+  }
+
+
+  @Test
+  @DisplayName("토큰 파싱 중 예외가 발생하면 SecurityContext를 비우고 체인을 진행한다")
+  void 토큰파싱_예외_컨텍스트초기화() throws ServletException, IOException {
+    // given
+    String token = "invalid.jwt.token";
+    given(jwtService.parse(token)).willThrow(new RuntimeException("parse error"));
+
+    // 미리 다른 인증이 들어있다고 가정(초기화 검증 목적)
+    SecurityContextHolder.getContext().setAuthentication(
+        new org.springframework.security.authentication.UsernamePasswordAuthenticationToken("before", null)
+    );
+
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.addHeader("Authorization", "Bearer " + token);
+    MockHttpServletResponse res = new MockHttpServletResponse();
+
+    // when
+    jwtFilter.doFilterInternal(req, res, chain);
+
+    // then
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    then(jwtService).should().parse(token);
+    then(memberRepository).shouldHaveNoInteractions();}
+
+}

--- a/src/test/java/com/example/blog/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/blog/auth/jwt/JwtAuthenticationFilterTest.java
@@ -32,7 +32,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
-@ActiveProfiles("test")
 public class JwtAuthenticationFilterTest {
 
   @Mock

--- a/src/test/java/com/example/blog/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/blog/auth/jwt/JwtAuthenticationFilterTest.java
@@ -29,8 +29,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class JwtAuthenticationFilterTest {
 
   @Mock

--- a/src/test/java/com/example/blog/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/example/blog/auth/jwt/JwtServiceTest.java
@@ -19,17 +19,17 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-@ActiveProfiles("test")
 public class JwtServiceTest {
   private JwtService jwtService;
-
+  private static final String TEST_SECRET = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+  private static final long TEST_ACCESS_EXP_MS = 60_000L;
+  private static final long TEST_REFRESH_EXP_MS = 1_209_600_000L;
   @BeforeEach
   void setUp(){
     jwtService = new JwtService();
-    ReflectionTestUtils.setField(jwtService, "secret",
-        "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF");
-    ReflectionTestUtils.setField(jwtService, "accessExpMs", 60_000L);
-    ReflectionTestUtils.setField(jwtService, "refreshExpMs", 1_209_600_000L);
+    ReflectionTestUtils.setField(jwtService, "secret", TEST_SECRET);
+    ReflectionTestUtils.setField(jwtService, "accessExpMs", TEST_ACCESS_EXP_MS);
+    ReflectionTestUtils.setField(jwtService, "refreshExpMs", TEST_REFRESH_EXP_MS);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class JwtServiceTest {
 
     String token = jwtService.generateAccessToken(member, "USER");
 
-    jwtService.assertValid(token);
+    assertThatNoException().isThrownBy(() -> jwtService.assertValid(token));
   }
 
   @Test

--- a/src/test/java/com/example/blog/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/example/blog/auth/jwt/JwtServiceTest.java
@@ -1,0 +1,118 @@
+package com.example.blog.auth.jwt;
+
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+import com.example.blog.common.exception.AuthException;
+import com.example.blog.domain.member.entity.Member;
+import io.jsonwebtoken.Claims;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class JwtServiceTest {
+  private JwtService jwtService;
+
+  @BeforeEach
+  void setUp(){
+    jwtService = new JwtService();
+    ReflectionTestUtils.setField(jwtService, "secret",
+        "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF");
+    ReflectionTestUtils.setField(jwtService, "accessExpMs", 60_000L);
+    ReflectionTestUtils.setField(jwtService, "refreshExpMs", 1_209_600_000L);
+  }
+
+  @Test
+  @DisplayName("액세스 토큰을 생성하고 파싱할 수 있다")
+  void 액세스_토큰을_생성하고_파싱할_수_있다(){
+    //given
+    UUID memberId = UUID.randomUUID();
+    Member member = mock(Member.class);
+    given(member.getId()).willReturn(memberId);
+    given(member.getEmail()).willReturn("test@gmail.com");
+    given(member.getName()).willReturn("test name");
+
+    //when
+    String accessToken = jwtService.generateAccessToken(member, "USER");
+    Claims claims = jwtService.parse(accessToken);
+
+    //then
+    assertThat(claims.getSubject()).isEqualTo(memberId.toString());
+    assertThat(claims.get("role")).isEqualTo("USER");
+    assertThat(claims.get("email")).isEqualTo("test@gmail.com");
+  }
+
+  @Test
+  @DisplayName("리프레시 토큰을 생성하고 파싱할 수 있다")
+  void 리프레시_토큰을_생성하고_파싱할_수_있다(){
+    // given
+    UUID memberId = UUID.randomUUID();
+
+    // when
+    String refreshToken = jwtService.generateRefreshToken(memberId);
+    Claims claims = jwtService.parse(refreshToken);
+
+    // then
+    assertThat(claims.getSubject()).isEqualTo(memberId.toString());
+  }
+
+  @Test
+  @DisplayName("토큰에서 만료시간을 추출할 수 있다")
+  void 토큰에서_만료시간을_추출할_수_있다(){
+    //given
+    UUID memberId = UUID.randomUUID();
+    Member member = mock(Member.class);
+    given(member.getId()).willReturn(memberId);
+    given(member.getEmail()).willReturn("test@gmail.com");
+    given(member.getName()).willReturn("test name");
+
+    //when
+    String token = jwtService.generateAccessToken(member, "USER");
+    Date date = jwtService.extractExpiration(token);
+
+    // then
+    assertThat(date).isAfterOrEqualTo(new Date());
+  }
+
+  @Test
+  @DisplayName("유효한 토큰은 검증을 통과한다")
+  void 유효한_토큰은_검증을_통과한다(){
+    // given
+    UUID memberId = UUID.randomUUID();
+    Member member = mock(Member.class);
+    given(member.getId()).willReturn(memberId);
+    given(member.getEmail()).willReturn("test@gmail.com");
+    given(member.getName()).willReturn("test name");
+
+    String token = jwtService.generateAccessToken(member, "USER");
+
+    jwtService.assertValid(token);
+  }
+
+  @Test
+  @DisplayName("만료시간이 지난 토큰은 검증을 실패한다")
+  void 만료시간이_지난_토큰은_검증을_실패한다(){
+    ReflectionTestUtils.setField(jwtService, "accessExpMs", -1_000L);
+    // given
+    UUID memberId = UUID.randomUUID();
+    Member member = mock(Member.class);
+    given(member.getId()).willReturn(memberId);
+    given(member.getEmail()).willReturn("test@gmail.com");
+    given(member.getName()).willReturn("test name");
+
+    String token = jwtService.generateAccessToken(member, "USER");
+
+    assertThatThrownBy(() -> jwtService.assertValid(token))
+        .isInstanceOf(AuthException.class);
+  }
+}

--- a/src/test/java/com/example/blog/auth/jwt/TokenInvalidationServiceTest.java
+++ b/src/test/java/com/example/blog/auth/jwt/TokenInvalidationServiceTest.java
@@ -1,0 +1,85 @@
+package com.example.blog.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.blog.auth.blacklist.Blacklist;
+import com.example.blog.common.exception.AuthException;
+import com.example.blog.common.exception.ErrorCode;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+public class TokenInvalidationServiceTest {
+  @Mock
+  private Blacklist blacklist;
+
+  private TokenInvalidationService service;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    service = new TokenInvalidationService(blacklist);
+  }
+
+  @Test
+  @DisplayName("invalidate 호출 시 블랙리스트에 토큰이 등록된다")
+  void invalidate_호출시_블랙리스트에_등록된다() {
+    // given
+    String token = "dummy-token";
+    Instant expiresAt = Instant.now().plusSeconds(60);
+
+    // when
+    service.invalidate(token, expiresAt);
+
+    // then
+    then(blacklist).should().addToBlackList(token, expiresAt);
+  }
+
+  @Test
+  @DisplayName("isInvalid은 블랙리스트 조회 결과를 반환한다")
+  void isInvalid은_블랙리스트_조회결과를_반환한다() {
+    // given
+    String token = "t1";
+    given(blacklist.exists(token)).willReturn(true);
+
+    // when
+    boolean result = service.isInvalid(token);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("assertNotInvalid는 블랙리스트 토큰일 경우 예외를 던진다")
+  void assertNotInvalid_블랙리스트면_예외() {
+    // given
+    String token = "invalid-token";
+    given(blacklist.exists(token)).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> service.assertNotInvalid(token))
+        .isInstanceOf(AuthException.class)
+        .hasMessage(ErrorCode.INVALID_TOKEN_ERROR.getMessage());
+  }
+
+  @Test
+  @DisplayName("assertNotInvalid는 정상 토큰일 경우 통과한다")
+  void assertNotInvalid_정상토큰은_통과() {
+    // given
+    String token = "valid-token";
+    given(blacklist.exists(token)).willReturn(false);
+
+    // when & then (예외 없음)
+    service.assertNotInvalid(token);
+  }
+}

--- a/src/test/java/com/example/blog/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/blog/auth/service/AuthServiceTest.java
@@ -1,0 +1,206 @@
+package com.example.blog.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+import com.example.blog.auth.dto.RegisterRequestDTO;
+import com.example.blog.auth.jwt.JwtService;
+import com.example.blog.auth.jwt.TokenInvalidationService;
+import com.example.blog.auth.user_details.CustomUserDetails;
+import com.example.blog.common.enumerated.MemberStatus;
+import com.example.blog.common.exception.AuthException;
+import com.example.blog.common.exception.ErrorCode;
+import com.example.blog.domain.member.dto.MemberResponseDto;
+import com.example.blog.domain.member.entity.Member;
+import com.example.blog.domain.member.entity.MemberRole;
+import com.example.blog.domain.member.repository.MemberRepository;
+import com.example.blog.domain.refresh_token.RefreshTokenRepository;
+import com.example.blog.domain.refresh_token.entity.RefreshToken;
+import com.example.blog.mapper.MemberMapper;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class AuthServiceTest {
+  @Mock
+  MemberRepository memberRepository;
+  @Mock
+  MemberMapper memberMapper;
+  @Mock
+  PasswordEncoder passwordEncoder;
+  @Mock
+  JwtService jwtService;
+  @Mock
+  TokenInvalidationService invalidationService;
+  @Mock
+  RefreshTokenRepository refreshTokenRepository;
+  @Mock
+  HttpServletRequest request;
+  @Mock
+  HttpServletResponse response;
+  @InjectMocks AuthServiceImpl authService;
+  Member m;
+  @BeforeEach
+  void setUp(){
+    ReflectionTestUtils.setField(authService, "cookieSecure", false);
+    m = new Member("email", "pwd", "nick", null, null,
+        MemberStatus.ACTIVE, null, "name", MemberRole.USER);
+    ReflectionTestUtils.setField(m, "id", UUID.randomUUID());
+  }
+
+  @Test
+  @DisplayName("회원가입 성공 시 비밀번호 인코딩 및 저장 후 DTO 반환")
+  void 회원가입_성공(){
+    // given
+    RegisterRequestDTO dto = new RegisterRequestDTO(
+        "email@test.com", "rawPw", "rawPw", "nick", "name");
+    given(memberRepository.findByEmail(dto.email())).willReturn(Optional.empty());
+    Member entity = new Member(dto.email(), null, dto.nickname(), null, null,
+        null, null, dto.name(), null);
+    given(memberMapper.toEntity(dto)).willReturn(entity);
+    given(passwordEncoder.encode("rawPw")).willReturn("ENCODED");
+
+    ArgumentCaptor<Member> saved = ArgumentCaptor.forClass(Member.class);
+    given(memberRepository.save(saved.capture())).willAnswer(i -> i.getArgument(0));
+
+    MemberResponseDto expectedDto = new MemberResponseDto(
+        UUID.randomUUID(), null, null, dto.email(), dto.nickname(),
+        null, MemberStatus.ACTIVE, null, dto.name(), MemberRole.USER);
+    given(memberMapper.toResponseDto(any(Member.class))).willReturn(expectedDto);
+
+    // when
+
+    MemberResponseDto res = authService.register(response, dto);
+    // then
+
+    Member savedMember = saved.getValue();
+    assertThat(savedMember.getEmail()).isEqualTo("email@test.com");
+    assertThat(savedMember.getPassword()).isEqualTo("ENCODED");
+  }
+
+  @Test
+  @DisplayName("회원가입 비밀번호 불일치 실패")
+  void 회원가입_비밀번호_불일치_실패(){
+    // given
+    RegisterRequestDTO dto = new RegisterRequestDTO(
+        "email@email.com", "pwd","diffPwd", "nick", "name"
+    );
+
+    // when & then
+    Assertions.assertThatThrownBy(()-> authService.register(response, dto)).isInstanceOf(
+        AuthException.class);
+  }
+
+  @Test
+  @DisplayName("회원가입시 중복 이메일 실패")
+  void 회원가입시_중복_이메일_실패(){
+    // given
+    RegisterRequestDTO dto = new RegisterRequestDTO(
+        "email@email.com", "pwd","pwd", "nick", "name"
+    );
+    Member member = mock(Member.class);
+    given(memberRepository.findByEmail(dto.email())).willReturn(Optional.of(member));
+
+    // when & then
+    Assertions.assertThatThrownBy(()-> authService.register(response, dto)).isInstanceOf(
+        AuthException.class);
+
+  }
+
+
+  @Test
+  @DisplayName("로그아웃 성공")
+  void 로그아웃_성공(){
+    // given
+    PrincipalMember principalMember = new CustomUserDetails(m);
+    String accessToken = "accessToken";
+    String refreshToken = "refreshToken";
+    Date expiration = new Date();
+
+    given(request.getHeader("Authorization")).willReturn("Bearer " + accessToken  );
+    given(jwtService.extractExpiration(accessToken)).willReturn(expiration);
+    given(request.getCookies()).willReturn(new Cookie[]{new Cookie("REFRESH_TOKEN", refreshToken)});
+    given(jwtService.extractExpiration(refreshToken)).willReturn(expiration);
+
+    // when
+    authService.signOut(request, response, principalMember);
+
+    // then
+    verify(invalidationService).invalidate(eq(accessToken), any());
+    verify(invalidationService).invalidate(eq(refreshToken), any());
+    verify(refreshTokenRepository).deleteById(any());
+
+  }
+
+  @Test
+  @DisplayName("리프레시 토큰 회전 성공")
+  void 리프레시_토큰_회전_성공(){
+    // given
+    String refreshToken = "refreshToken";
+    String newAccessToken = "newAccessToken";
+    String newRefreshToken = "newRefreshToken";
+    RefreshToken storedToken = new RefreshToken(m.getId(), refreshToken);
+    Cookie refreshCookie = new Cookie("REFRESH_TOKEN", refreshToken);
+    Claims c = mock(Claims.class);
+
+    given(request.getCookies()).willReturn(new Cookie[]{refreshCookie});
+    willDoNothing().given(jwtService).assertValid(any());
+    willDoNothing().given(invalidationService).assertNotInvalid(any());
+    given(jwtService.parse(any())).willReturn(c);
+    given(jwtService.parse(any()).getSubject()).willReturn(m.getId().toString());
+    given(refreshTokenRepository.findById(m.getId())).willReturn(Optional.of(storedToken));
+    given(memberRepository.findById(m.getId())).willReturn(Optional.ofNullable(m));
+    given(jwtService.generateAccessToken(m, m.getRole().name()))
+        .willReturn(newAccessToken);
+    given(jwtService.generateRefreshToken(m.getId()))
+        .willReturn(newRefreshToken);
+    given(refreshTokenRepository.save(any(RefreshToken.class))).willReturn(storedToken);
+    given(jwtService.extractExpiration(refreshToken)).willReturn(new Date());
+
+    ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+
+    //when
+    Map<String, Object> result = authService.refresh(request, response);
+
+    //then
+    assertThat(result).isNotEmpty();
+    assertThat(result.get("accessToken")).isEqualTo(newAccessToken);
+    verify(refreshTokenRepository).save(captor.capture());
+  }
+
+  @Test
+  @DisplayName("리프레시_유효하지_않은_토큰_실패")
+  void 리프레시_유효하지_않은_토큰_실패() {
+    // given
+    given(request.getCookies()).willReturn(new Cookie[]{new Cookie("REFRESH_TOKEN", "invalidToken")});
+    willThrow(new AuthException(ErrorCode.INVALID_TOKEN_ERROR)).given(jwtService).assertValid("invalidToken");
+
+    // when & then
+    AuthException exception = assertThrows(AuthException.class, () -> authService.refresh(request, response));
+    assertEquals(ErrorCode.INVALID_TOKEN_ERROR, exception.getErrorCode());
+    verify(refreshTokenRepository, never()).save(any());
+  }
+}

--- a/src/test/java/com/example/blog/common/policy/S3ProfileImageKeyPolicyTest.java
+++ b/src/test/java/com/example/blog/common/policy/S3ProfileImageKeyPolicyTest.java
@@ -1,0 +1,57 @@
+package com.example.blog.common.policy;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.blog.common.exception.ErrorCode;
+import com.example.blog.common.exception.MemberException;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class S3ProfileImageKeyPolicyTest {
+
+  S3ProfileImageKeyPolicy policy;
+  String expectedPrefix = "https://test-url.com/";
+
+  @BeforeEach
+  void setUp(){
+    policy = new S3ProfileImageKeyPolicy();
+    ReflectionTestUtils.setField(policy, "expectedPrefix", expectedPrefix);
+  }
+
+  @Test
+  @DisplayName("소유자의 url이 맞을경우 통과")
+  void 소유자의_url이_맞을경우_통과(){
+    UUID randomId = UUID.randomUUID();
+    String key = expectedPrefix + randomId.toString();
+
+    assertThatCode(() -> policy.validateOwnedKey(key, randomId))
+        .doesNotThrowAnyException();
+  }
+  @Test
+  @DisplayName("소유자의 url이 아닐 경우 예외 발생")
+  void 소유자의_url이_아닐_경우_예외_발생() {
+    UUID randomId = UUID.randomUUID();
+    String anotherUser = UUID.randomUUID().toString();
+    String key = expectedPrefix + anotherUser + "/profile.png";
+
+    assertThatThrownBy(() -> policy.validateOwnedKey(key, randomId))
+        .isInstanceOf(MemberException.class);
+  }
+
+  @Test
+  @DisplayName("key가 null 또는 빈 문자열일 경우 통과")
+  void key가_null_또는_빈문자열일_경우_통과() {
+    UUID randomId = UUID.randomUUID();
+
+    assertThatCode(() -> policy.validateOwnedKey(null, randomId))
+        .doesNotThrowAnyException();
+
+    assertThatCode(() -> policy.validateOwnedKey("", randomId))
+        .doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/com/example/blog/domain/member/MemberServiceImplTest.java
+++ b/src/test/java/com/example/blog/domain/member/MemberServiceImplTest.java
@@ -1,0 +1,88 @@
+package com.example.blog.domain.member;
+
+
+import static org.mockito.BDDMockito.*;
+
+import com.example.blog.auth.service.PrincipalMember;
+import com.example.blog.auth.user_details.CustomUserDetails;
+import com.example.blog.common.enumerated.MemberStatus;
+import com.example.blog.common.enumerated.Provider;
+import com.example.blog.common.policy.interf.ProfileImageKeyPolicy;
+import com.example.blog.domain.member.dto.UpdateMemberRequestDto;
+import com.example.blog.domain.member.entity.Member;
+import com.example.blog.domain.member.entity.MemberRole;
+import com.example.blog.domain.member.repository.MemberRepository;
+import com.example.blog.domain.member.service.MemberServiceImpl;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceImplTest {
+
+  @Mock
+  MemberRepository memberRepository;
+  @Mock
+  PasswordEncoder encoder;
+  @Mock
+  ProfileImageKeyPolicy policy;
+
+  @InjectMocks
+  MemberServiceImpl memberService;
+  Member member;
+
+  @BeforeEach
+  void setUp(){
+    member = new Member("email@email.com", "pwd", "nick", null, null, MemberStatus.ACTIVE, null, "name", MemberRole.USER);
+    ReflectionTestUtils.setField(member, "id", UUID.randomUUID());
+  }
+
+
+  @Test
+  @DisplayName("유효한 데이터로 사용자를 업데이트 할 수 있다")
+  void 유효한_데이터로_사용자를_업데이트할_수_있다(){
+    // given
+    UpdateMemberRequestDto updateDto = new UpdateMemberRequestDto("update nick", "newPwd", "pwd", "s3Key");
+    PrincipalMember principalMember = new CustomUserDetails(member);
+    given(memberRepository.findById(member.getId())).willReturn(
+        Optional.ofNullable(member));
+    given(encoder.matches(anyString(), anyString())).willReturn(true);
+    given(encoder.encode(anyString())).willReturn(updateDto.password());
+    willDoNothing().given(policy).validateOwnedKey(anyString(), any());
+
+    // when
+    Member member1 = memberService.updateMember(updateDto, principalMember  );
+
+    // then
+    Assertions.assertThat(member1.getNickname()).isEqualTo("update nick");
+  }
+
+  @Test
+  @DisplayName("provider존재시 비밀번호 업데이트를 하지 않는다")
+  void provider존재시_비밀번호_업데이트를_하지_않는다(){
+    // given
+    ReflectionTestUtils.setField(member, "provider", Provider.GOOGLE);
+    UpdateMemberRequestDto updateDto = new UpdateMemberRequestDto("update nick", "newPwd", "pwd", "s3Key");
+    PrincipalMember principalMember = new CustomUserDetails(member);
+    given(memberRepository.findById(member.getId())).willReturn(
+        Optional.ofNullable(member));
+    willDoNothing().given(policy).validateOwnedKey(anyString(), any());
+
+    //when
+    Member member1 = memberService.updateMember(updateDto, principalMember  );
+
+    //then
+    Assertions.assertThat(member1.getNickname()).isEqualTo("update nick");
+    verifyNoInteractions(encoder);
+  }
+}

--- a/src/test/java/com/example/blog/mapper/MemberMapperTest.java
+++ b/src/test/java/com/example/blog/mapper/MemberMapperTest.java
@@ -1,0 +1,91 @@
+package com.example.blog.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+import com.example.blog.auth.dto.RegisterRequestDTO;
+import com.example.blog.common.enumerated.MemberStatus;
+import com.example.blog.common.enumerated.Provider;
+import com.example.blog.common.utils.S3UrlMapper;
+import com.example.blog.domain.member.dto.MemberResponseDto;
+import com.example.blog.domain.member.entity.Member;
+import com.example.blog.domain.member.entity.MemberRole;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+
+public class MemberMapperTest {
+
+  MemberMapper memberMapper;
+
+  @BeforeEach
+  void setUp(){
+    memberMapper = new MemberMapperImpl();
+  }
+
+  @Test
+  @DisplayName("회원가입 DTO를 mapping 할수 있다")
+  void 회원가입_DTO를_매핑할_수_있다(){
+    // given
+    RegisterRequestDTO dto = new RegisterRequestDTO("email@email.com", "pwd", "pwd", "nick", "name");
+
+    // when
+    Member member = memberMapper.toEntity(dto);
+
+    // then
+    assertThat(member.getEmail()).isEqualTo(dto.email());
+    assertThat(member.getNickname()).isEqualTo("nick");
+  }
+
+  @Test
+  @DisplayName("OAuth정보를 매핑할 수 있다")
+  void OAuth_정보를_매핑할_수_있다(){
+    // given
+    String name = "name";
+    String email = "email@email.com";
+    String providerId = UUID.randomUUID().toString();
+    Provider provider = Provider.GOOGLE;
+    String nickname = "nick";
+
+    // when
+    Member member = memberMapper.fromOAuthToMember(name, email, providerId, provider, nickname);
+
+    // then
+    assertThat(member.getName()).isEqualTo(name);
+    assertThat(member.getEmail()).isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("Member를 MemberResponseDto로 매핑할 수 있다")
+  void Member를_MemberResponseDto_로_매핑할_수_있다(){
+    // given
+    String name = "name";
+    String email = "email@email.com";
+    String providerId = UUID.randomUUID().toString();
+    Provider provider = Provider.GOOGLE;
+    String nickname = "nick";
+    String url = "https://test-url.com";
+    Member member = new Member(email, "pwd", nickname, provider, providerId, MemberStatus.ACTIVE, null, name, MemberRole.USER );
+    ReflectionTestUtils.setField(member, "id", UUID.randomUUID());
+    S3UrlMapper s3UrlMapper = mock(S3UrlMapper.class);
+    ReflectionTestUtils.setField(memberMapper, "s3UrlMapper", s3UrlMapper);
+    BDDMockito.given(s3UrlMapper.toPublicUrl(any())).willReturn(url );
+
+    // when
+    MemberResponseDto responseDto = memberMapper.toResponseDto(member);
+
+    // then
+    assertThat(responseDto.email()).isEqualTo(email);
+    assertThat(responseDto.name()).isEqualTo(name);
+    assertThat(responseDto.profileUrl()).isEqualTo(url);
+
+  }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,52 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-client
+            client-secret: test-secret
+            scope: profile,email
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+
+app:
+  cookies:
+    secure: false
+  jwt:
+    secret: test-test-test-test-test-test-test
+  client-url: "http://localhost:3000"
+  aws:
+    s3:
+      bucket: dummy
+      bucket-url: dummy
+custom:
+  oauth2:
+    base-url: "http://localhost:8080"
+
+cloud:
+  aws:
+    credentials:
+      accessKey: dummy
+      secretKey: dummy
+    region:
+      static: ap-northeast-2
+    presigned-url-expiration: 600
+    expected-prefix: uploads/profile/
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
     driverClassName: org.h2.Driver
     username: sa
     password:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,6 +31,8 @@ app:
     secure: false
   jwt:
     secret: test-test-test-test-test-test-test
+    access-exp-ms: 3600000
+    refresh-exp-ms: 1209600000
   client-url: "http://localhost:3000"
   aws:
     s3:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Authentication now expects JWT in the Authorization: Bearer header (cookies removed).
  - Token handling updated: configurable access/refresh expirations; improved sign-out and refresh rotation flows.
  - Password updates for local accounts now validate the current password.

- Chores
  - CI workflow added to run tests and enforce ~80% coverage, with HTML reports uploaded.

- Tests
  - Many new unit tests and a dedicated test profile for isolated test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->