### PR TITLE
feat: 블로그 관련 pagination 및  테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	implementation 'org.postgresql:postgresql:42.7.4' // postgresql
+	testImplementation "org.testcontainers:junit-jupiter"
+	testImplementation "org.testcontainers:postgresql"
+
 
 	// aws
 	implementation 'software.amazon.awssdk:s3:2.25.48'

--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,17 @@ dependencies {
 	//oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	implementation 'com.querydsl:querydsl-jpa:5.0.0' // querydsl
-
 	implementation 'org.postgresql:postgresql:42.7.4' // postgresql
 
 	// aws
 	implementation 'software.amazon.awssdk:s3:2.25.48'
 	implementation 'software.amazon.awssdk:sts:2.25.48'
+
+	implementation "com.querydsl:querydsl-jpa:5.1.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 test {

--- a/src/main/java/com/example/blog/common/config/QuerydslConfig.java
+++ b/src/main/java/com/example/blog/common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.blog.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/main/java/com/example/blog/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/blog/common/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                 "/api/public/**",
                 "/api/token/refresh",
                 "/oauth2/**",
-                "/api/auth/**"
+                "/api/auth/**",
+                "/api/member/{memberId}/blogs"
             )
             .permitAll()
             .requestMatchers("/favicon.ico").permitAll()

--- a/src/main/java/com/example/blog/common/pagenation/Direction.java
+++ b/src/main/java/com/example/blog/common/pagenation/Direction.java
@@ -1,0 +1,12 @@
+package com.example.blog.common.pagenation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum Direction {
+  DESC, ASC;
+
+  @JsonCreator
+  public static Direction from(String value) {
+    return Direction.valueOf(value.toUpperCase());
+  }
+}

--- a/src/main/java/com/example/blog/common/pagenation/PageInfo.java
+++ b/src/main/java/com/example/blog/common/pagenation/PageInfo.java
@@ -1,0 +1,13 @@
+package com.example.blog.common.pagenation;
+
+import java.util.UUID;
+
+public record PageInfo(
+    long count,
+    long limit,
+    long total,
+    UUID nextCursor,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/example/blog/common/pagenation/PaginatedResponse.java
+++ b/src/main/java/com/example/blog/common/pagenation/PaginatedResponse.java
@@ -1,0 +1,10 @@
+package com.example.blog.common.pagenation;
+
+import java.util.List;
+
+public record PaginatedResponse<T>(
+    List<T> items,
+    PageInfo pageInfo
+) {
+
+}

--- a/src/main/java/com/example/blog/common/pagenation/PaginationUtil.java
+++ b/src/main/java/com/example/blog/common/pagenation/PaginationUtil.java
@@ -1,0 +1,30 @@
+package com.example.blog.common.pagenation;
+
+import com.example.blog.domain.base.BaseEntity;
+import java.util.List;
+import java.util.UUID;
+
+public class PaginationUtil {
+  private PaginationUtil() {}
+  public static <T extends BaseEntity> PageInfo createPageInfo(List<T> entities, long limit) {
+    boolean hasNext = hasNext(entities.size(), (int) limit);
+
+    if (hasNext) {
+      entities.remove(entities.size() - 1);
+    }
+
+    UUID lastId = entities.isEmpty() ? null : entities.get(entities.size() - 1).getId();
+
+    return new PageInfo(
+        entities.size(),
+        limit,
+        0, // TODO: totalCount 필요하다면 별도 조회
+        lastId,
+        hasNext
+    );
+  }
+
+  private static boolean hasNext(int size, int limit) {
+    return limit < size;
+  }
+}

--- a/src/main/java/com/example/blog/common/pagenation/SortBy.java
+++ b/src/main/java/com/example/blog/common/pagenation/SortBy.java
@@ -1,0 +1,12 @@
+package com.example.blog.common.pagenation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum SortBy {
+  FOLLOWERS, POSTS, VIEWS;
+
+  @JsonCreator
+  public static SortBy from(String value) {
+    return SortBy.valueOf(value.toUpperCase());
+  }
+}

--- a/src/main/java/com/example/blog/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/example/blog/domain/blog/controller/BlogController.java
@@ -1,34 +1,49 @@
 package com.example.blog.domain.blog.controller;
 
 
-
 import com.example.blog.auth.user_details.CustomPrincipal;
+import com.example.blog.common.pagenation.PaginatedResponse;
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
 import com.example.blog.domain.blog.dto.BlogResponseDto;
 import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
-import com.example.blog.domain.blog.service.BlogService;
+import com.example.blog.domain.blog.facade.BlogFacade;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/blogs")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class BlogController {
 
 
-  private final BlogService blogService;
+  private final BlogFacade blogFacade;
 
-  @PostMapping
+  @PostMapping("/blogs")
   public ResponseEntity<BlogResponseDto> createBlog(@RequestBody CreateBlogRequestDto blogRequest, @AuthenticationPrincipal
       CustomPrincipal principal){
 
-    BlogResponseDto responseDto = blogService.createBlog(blogRequest, principal);
+    BlogResponseDto responseDto = blogFacade.createBlog(blogRequest, principal);
 
     return ResponseEntity.ok(responseDto);
+  }
+
+  @GetMapping("/member/{memberId}/blogs")
+  public ResponseEntity<PaginatedResponse<BlogResponseDto>> getMemberBlogs(
+      @PathVariable UUID memberId,
+      @ModelAttribute BlogPaginationRequest blogRequest
+  ){
+
+    PaginatedResponse<BlogResponseDto> res = blogFacade.getMemberBlogs(memberId, blogRequest);
+
+    return ResponseEntity.ok(res);
   }
 }

--- a/src/main/java/com/example/blog/domain/blog/dto/BlogPaginationRequest.java
+++ b/src/main/java/com/example/blog/domain/blog/dto/BlogPaginationRequest.java
@@ -1,0 +1,18 @@
+package com.example.blog.domain.blog.dto;
+
+import com.example.blog.common.pagenation.Direction;
+import com.example.blog.common.pagenation.SortBy;
+import java.util.UUID;
+
+public record BlogPaginationRequest(
+    SortBy sortBy,
+    Direction direction,
+    long limit,
+    UUID cursor
+) {
+  public BlogPaginationRequest{
+    if(sortBy == null) sortBy = SortBy.FOLLOWERS;
+    if(direction == null) direction = Direction.DESC;
+    if(limit <= 0) limit = 10;
+  }
+}

--- a/src/main/java/com/example/blog/domain/blog/dto/BlogResponseDto.java
+++ b/src/main/java/com/example/blog/domain/blog/dto/BlogResponseDto.java
@@ -4,7 +4,9 @@ import com.example.blog.domain.blog.entity.BlogVisibility;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record BlogResponseDto(
    UUID blogId,
    UUID memberId,

--- a/src/main/java/com/example/blog/domain/blog/entity/Blog.java
+++ b/src/main/java/com/example/blog/domain/blog/entity/Blog.java
@@ -57,4 +57,10 @@ public class Blog extends BaseUpdatableEntity {
     }
     tags.forEach(tag -> this.blogTags.add(new BlogTag(this, tag)));
   }
+
+  public List<String> getTagNames() {
+    return blogTags.stream()
+        .map(bt -> bt.getTag().getName())
+        .toList();
+  }
 }

--- a/src/main/java/com/example/blog/domain/blog/facade/BlogFacade.java
+++ b/src/main/java/com/example/blog/domain/blog/facade/BlogFacade.java
@@ -1,21 +1,13 @@
-package com.example.blog.domain.blog.service;
+package com.example.blog.domain.blog.facade;
 
 import com.example.blog.auth.user_details.CustomPrincipal;
 import com.example.blog.common.pagenation.PaginatedResponse;
 import com.example.blog.domain.blog.dto.BlogPaginationRequest;
 import com.example.blog.domain.blog.dto.BlogResponseDto;
 import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
-import com.example.blog.domain.blog.entity.Blog;
-import com.example.blog.domain.tag.entity.Tag;
-import java.util.List;
 import java.util.UUID;
 
-public interface BlogService {
-  Blog createBlog(CreateBlogRequestDto request, CustomPrincipal principal);
-
-  void addTags(List<Tag> tags, Blog blog);
-
-  Blog saveBlog(Blog blog);
-
+public interface BlogFacade {
+  BlogResponseDto createBlog(CreateBlogRequestDto request, CustomPrincipal principal);
   PaginatedResponse<BlogResponseDto> getMemberBlogs(UUID memberId, BlogPaginationRequest request);
 }

--- a/src/main/java/com/example/blog/domain/blog/facade/BlogFacadeImpl.java
+++ b/src/main/java/com/example/blog/domain/blog/facade/BlogFacadeImpl.java
@@ -8,6 +8,7 @@ import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
 import com.example.blog.domain.blog.entity.Blog;
 import com.example.blog.domain.blog.service.BlogService;
 import com.example.blog.domain.blog_stat.service.BlogStatService;
+import com.example.blog.domain.member.service.MemberService;
 import com.example.blog.domain.tag.entity.Tag;
 import com.example.blog.domain.tag.service.TagService;
 import com.example.blog.mapper.BlogMapper;
@@ -24,6 +25,7 @@ public class BlogFacadeImpl implements BlogFacade{
   private final TagService tagService;
   private final BlogStatService blogStatService;
   private final BlogMapper blogMapper;
+  private final MemberService memberService;
 
   @Override
   public BlogResponseDto createBlog(CreateBlogRequestDto request, CustomPrincipal principal) {
@@ -40,6 +42,7 @@ public class BlogFacadeImpl implements BlogFacade{
   @Override
   public PaginatedResponse<BlogResponseDto> getMemberBlogs(UUID memberId,
       BlogPaginationRequest request) {
+    memberService.findMemberById(memberId);
     return blogService.getMemberBlogs(memberId, request);
   }
 }

--- a/src/main/java/com/example/blog/domain/blog/facade/BlogFacadeImpl.java
+++ b/src/main/java/com/example/blog/domain/blog/facade/BlogFacadeImpl.java
@@ -1,0 +1,45 @@
+package com.example.blog.domain.blog.facade;
+
+import com.example.blog.auth.user_details.CustomPrincipal;
+import com.example.blog.common.pagenation.PaginatedResponse;
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
+import com.example.blog.domain.blog.dto.BlogResponseDto;
+import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog.service.BlogService;
+import com.example.blog.domain.blog_stat.service.BlogStatService;
+import com.example.blog.domain.tag.entity.Tag;
+import com.example.blog.domain.tag.service.TagService;
+import com.example.blog.mapper.BlogMapper;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BlogFacadeImpl implements BlogFacade{
+
+  private final BlogService blogService;
+  private final TagService tagService;
+  private final BlogStatService blogStatService;
+  private final BlogMapper blogMapper;
+
+  @Override
+  public BlogResponseDto createBlog(CreateBlogRequestDto request, CustomPrincipal principal) {
+    Blog blog = blogService.createBlog(request, principal);
+    List<Tag> tags = tagService.getOrCreateTags(request.tags());
+    blogService.addTags(tags, blog);
+    Blog saved = blogService.saveBlog(blog);
+
+    blogStatService.createBlogStat(blog); // TODO: 이벤트 분리
+
+    return blogMapper.toResponse(blog);
+  }
+
+  @Override
+  public PaginatedResponse<BlogResponseDto> getMemberBlogs(UUID memberId,
+      BlogPaginationRequest request) {
+    return blogService.getMemberBlogs(memberId, request);
+  }
+}

--- a/src/main/java/com/example/blog/domain/blog/respository/BlogQueryRepository.java
+++ b/src/main/java/com/example/blog/domain/blog/respository/BlogQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.blog.domain.blog.respository;
+
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
+import com.example.blog.domain.blog.entity.Blog;
+import java.util.List;
+import java.util.UUID;
+
+public interface BlogQueryRepository {
+  List<Blog> findByMemberIdAndQuery(UUID memberId, BlogPaginationRequest request);
+}

--- a/src/main/java/com/example/blog/domain/blog/respository/BlogQueryRepositoryImpl.java
+++ b/src/main/java/com/example/blog/domain/blog/respository/BlogQueryRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.example.blog.domain.blog.respository;
+
+
+import com.example.blog.common.pagenation.Direction;
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog.entity.QBlog;
+import com.example.blog.domain.blog_stat.entity.QBlogStat;
+import com.example.blog.domain.blog_tag.entity.QBlogTag;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BlogQueryRepositoryImpl implements BlogQueryRepository{
+  private final JPAQueryFactory queryFactory;
+
+  public List<Blog> findByMemberIdAndQuery(UUID memberId, BlogPaginationRequest request){
+    QBlog blog = QBlog.blog;
+    QBlogStat blogStat = QBlogStat.blogStat;
+    QBlogTag blogTag = QBlogTag.blogTag;
+
+    BooleanBuilder builder = new BooleanBuilder();
+    builder.and(blog.member.id.eq(memberId));
+
+    OrderSpecifier<?> orderSpecifier = switch (request.sortBy()) {
+      case VIEWS -> request.direction() == Direction.ASC ?
+          blogStat.viewCount.asc() : blogStat.viewCount.desc();
+      case POSTS -> request.direction() == Direction.ASC ?
+          blogStat.postCount.asc() : blogStat.postCount.desc();
+      case FOLLOWERS -> request.direction() == Direction.ASC ?
+          blogStat.followerCount.asc() : blogStat.followerCount.desc();
+    };
+
+    return queryFactory
+        .selectFrom(blog)
+        .join(blogStat).on(blog.id.eq(blogStat.blog.id)).fetchJoin()
+        .join(blogTag).on(blog.id.eq(blogTag.blog.id)).fetchJoin()
+        .where(builder)
+        .orderBy(orderSpecifier)
+        .limit(request.limit() + 1) // for HasNext
+        .fetch();
+  }
+}

--- a/src/main/java/com/example/blog/domain/blog/respository/BlogRepository.java
+++ b/src/main/java/com/example/blog/domain/blog/respository/BlogRepository.java
@@ -5,6 +5,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BlogRepository extends JpaRepository<Blog, UUID> {
+public interface BlogRepository extends JpaRepository<Blog, UUID>, BlogQueryRepository {
   Optional<Blog> findBySlug(String slug);
 }

--- a/src/main/java/com/example/blog/domain/blog/respository/BlogRepositoryAdapter.java
+++ b/src/main/java/com/example/blog/domain/blog/respository/BlogRepositoryAdapter.java
@@ -1,7 +1,10 @@
 package com.example.blog.domain.blog.respository;
 
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
 import com.example.blog.domain.blog.entity.Blog;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Component;
 public class BlogRepositoryAdapter implements BlogRepositoryPort{
 
   private final BlogRepository blogRepository;
+
   @Override
   public Optional<Blog> findBySlug(String slug) {
     return blogRepository.findBySlug(slug);
@@ -19,5 +23,10 @@ public class BlogRepositoryAdapter implements BlogRepositoryPort{
   @Override
   public Blog save(Blog blog) {
     return blogRepository.save(blog);
+  }
+
+  @Override
+  public List<Blog> findByMemberIdAndQuery(UUID memberId, BlogPaginationRequest query) {
+    return blogRepository.findByMemberIdAndQuery(memberId, query);
   }
 }

--- a/src/main/java/com/example/blog/domain/blog/respository/BlogRepositoryPort.java
+++ b/src/main/java/com/example/blog/domain/blog/respository/BlogRepositoryPort.java
@@ -1,10 +1,13 @@
 package com.example.blog.domain.blog.respository;
 
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
 import com.example.blog.domain.blog.entity.Blog;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface BlogRepositoryPort {
   Optional<Blog> findBySlug(String slug);
   Blog save(Blog blog);
-
+  List<Blog> findByMemberIdAndQuery(UUID memberId, BlogPaginationRequest query);
 }

--- a/src/main/java/com/example/blog/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/example/blog/domain/blog/service/BlogServiceImpl.java
@@ -59,17 +59,9 @@ public class BlogServiceImpl implements BlogService{
   @Override
   @Transactional
   public PaginatedResponse<BlogResponseDto> getMemberBlogs(UUID memberId, BlogPaginationRequest request) {
-    memberPort.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
-
     List<Blog> blogs = blogPort.findByMemberIdAndQuery(memberId, request);
     PageInfo pageInfo = PaginationUtil.createPageInfo(blogs, request.limit());
     List<BlogResponseDto> responseDtoList = blogMapper.toResponseList(blogs);
     return new PaginatedResponse<>(responseDtoList, pageInfo);
   }
-
-  private boolean queryResultHasNext(int size, int target){
-    return target < size;
-  }
-
-
 }

--- a/src/main/java/com/example/blog/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/example/blog/domain/blog/service/BlogServiceImpl.java
@@ -4,6 +4,10 @@ import com.example.blog.auth.user_details.CustomPrincipal;
 import com.example.blog.common.exception.BlogException;
 import com.example.blog.common.exception.ErrorCode;
 import com.example.blog.common.exception.MemberException;
+import com.example.blog.common.pagenation.PageInfo;
+import com.example.blog.common.pagenation.PaginatedResponse;
+import com.example.blog.common.pagenation.PaginationUtil;
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
 import com.example.blog.domain.blog.dto.BlogResponseDto;
 import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
 import com.example.blog.domain.blog.entity.Blog;
@@ -11,9 +15,9 @@ import com.example.blog.domain.blog.respository.BlogRepositoryPort;
 import com.example.blog.domain.member.entity.Member;
 import com.example.blog.domain.member.repository.MemberRepositoryPort;
 import com.example.blog.domain.tag.entity.Tag;
-import com.example.blog.domain.tag.service.TagService;
 import com.example.blog.mapper.BlogMapper;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,10 +31,10 @@ public class BlogServiceImpl implements BlogService{
   private final MemberRepositoryPort memberPort;
   private final BlogRepositoryPort blogPort;
   private final BlogMapper blogMapper;
-  private final TagService tagService;
+
   @Override
   @Transactional
-  public BlogResponseDto createBlog(CreateBlogRequestDto request, CustomPrincipal principal) {
+  public Blog createBlog(CreateBlogRequestDto request, CustomPrincipal principal) {
 
     if (blogPort.findBySlug(request.slug()).isPresent()) {
       throw new BlogException(ErrorCode.DUPLICATE_SLUG_EXCEPTION);
@@ -38,14 +42,34 @@ public class BlogServiceImpl implements BlogService{
 
     Member member = memberPort.findById(principal.id())
         .orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
-    List<Tag> tags = tagService.getOrCreateTags(request.tags());
-    List<String> tagStrings = tags.stream().map(Tag::getName).toList();
 
-    Blog blog = blogMapper.toEntity(request, member);
-    blog.addTags(tags);
-    Blog saved = blogPort.save(blog);
-
-    return blogMapper.toResponse(blog, tagStrings);
-
+    return blogMapper.toEntity(request, member);
   }
+
+  @Override
+  public void addTags(List<Tag> tags, Blog blog){
+    blog.addTags(tags);
+  }
+
+  @Override
+  public Blog saveBlog(Blog blog){
+    return blogPort.save(blog);
+  }
+
+  @Override
+  @Transactional
+  public PaginatedResponse<BlogResponseDto> getMemberBlogs(UUID memberId, BlogPaginationRequest request) {
+    memberPort.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
+
+    List<Blog> blogs = blogPort.findByMemberIdAndQuery(memberId, request);
+    PageInfo pageInfo = PaginationUtil.createPageInfo(blogs, request.limit());
+    List<BlogResponseDto> responseDtoList = blogMapper.toResponseList(blogs);
+    return new PaginatedResponse<>(responseDtoList, pageInfo);
+  }
+
+  private boolean queryResultHasNext(int size, int target){
+    return target < size;
+  }
+
+
 }

--- a/src/main/java/com/example/blog/domain/blog_stat/entity/BlogStat.java
+++ b/src/main/java/com/example/blog/domain/blog_stat/entity/BlogStat.java
@@ -1,6 +1,5 @@
 package com.example.blog.domain.blog_stat.entity;
 
-import com.example.blog.domain.base.BaseEntity;
 import com.example.blog.domain.blog.entity.Blog;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,18 +12,16 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.PreUpdate;
 import java.time.Instant;
 import java.util.UUID;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class BlogStat {
-
   @Id
   @Column(columnDefinition = "UUID")
   private UUID id;
@@ -53,5 +50,10 @@ public class BlogStat {
   @PreUpdate
   private void onUpdate(){
     this.updatedAt = Instant.now();
+  }
+
+  public void setBlog(Blog blog){
+    if(blog == null) return;
+    this.blog = blog;
   }
 }

--- a/src/main/java/com/example/blog/domain/blog_stat/repository/BlogStatRepository.java
+++ b/src/main/java/com/example/blog/domain/blog_stat/repository/BlogStatRepository.java
@@ -1,0 +1,9 @@
+package com.example.blog.domain.blog_stat.repository;
+
+import com.example.blog.domain.blog_stat.entity.BlogStat;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogStatRepository extends JpaRepository<BlogStat, UUID> {
+
+}

--- a/src/main/java/com/example/blog/domain/blog_stat/service/BlogStatService.java
+++ b/src/main/java/com/example/blog/domain/blog_stat/service/BlogStatService.java
@@ -1,0 +1,8 @@
+package com.example.blog.domain.blog_stat.service;
+
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog_stat.entity.BlogStat;
+
+public interface BlogStatService {
+  BlogStat createBlogStat(Blog blog);
+}

--- a/src/main/java/com/example/blog/domain/blog_stat/service/BlogStatServiceImpl.java
+++ b/src/main/java/com/example/blog/domain/blog_stat/service/BlogStatServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.blog.domain.blog_stat.service;
+
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog_stat.entity.BlogStat;
+import com.example.blog.domain.blog_stat.repository.BlogStatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class BlogStatServiceImpl implements BlogStatService{
+
+  private final BlogStatRepository blogStatRepository;
+  @Override
+  public BlogStat createBlogStat(Blog blog) {
+
+    BlogStat stat = new BlogStat();
+    stat.setBlog(blog);
+    blogStatRepository.save(stat);
+
+    return stat;
+  }
+}

--- a/src/main/java/com/example/blog/domain/blog_tag/repository/BlogTagRepository.java
+++ b/src/main/java/com/example/blog/domain/blog_tag/repository/BlogTagRepository.java
@@ -1,0 +1,18 @@
+package com.example.blog.domain.blog_tag.repository;
+
+import com.example.blog.domain.blog_tag.entity.BlogTag;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface BlogTagRepository extends JpaRepository<BlogTag, UUID> {
+
+  @Query("""
+        SELECT bt
+        FROM blog_tags bt
+        JOIN FETCH bt.tag t
+        WHERE bt.blog.id IN :blogIds
+  """)
+  List<BlogTag> findAllByBlogId(List<UUID> blogIds);
+}

--- a/src/main/java/com/example/blog/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/blog/domain/member/service/MemberService.java
@@ -4,8 +4,10 @@ package com.example.blog.domain.member.service;
 import com.example.blog.auth.user_details.CustomPrincipal;
 import com.example.blog.domain.member.dto.UpdateMemberRequestDto;
 import com.example.blog.domain.member.entity.Member;
+import java.util.UUID;
 
 public interface MemberService {
   Member findMember(CustomPrincipal principal);
   Member updateMember(UpdateMemberRequestDto request, CustomPrincipal principal);
+  Member findMemberById(UUID memberId);
 }

--- a/src/main/java/com/example/blog/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/blog/domain/member/service/MemberServiceImpl.java
@@ -48,6 +48,11 @@ public class MemberServiceImpl implements MemberService {
     return foundMember;
   }
 
+  @Override
+  public Member findMemberById(UUID memberId) {
+    return memberPort.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.USER_NOT_FOUND));
+  }
+
   private void validatePassword(String currentPassword, String originalPassword){
     if(!encoder.matches(currentPassword, originalPassword)){
       throw new AuthException(ErrorCode.PASSWORD_MATCH_ERROR);

--- a/src/main/java/com/example/blog/mapper/BlogMapper.java
+++ b/src/main/java/com/example/blog/mapper/BlogMapper.java
@@ -4,7 +4,6 @@ import com.example.blog.domain.blog.dto.BlogResponseDto;
 import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
 import com.example.blog.domain.blog.entity.Blog;
 import com.example.blog.domain.member.entity.Member;
-import com.example.blog.domain.tag.entity.Tag;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -23,4 +22,21 @@ public interface BlogMapper {
   @Mapping(target = "memberId", source = "blog.member.id")
   @Mapping(target = "tags", source = "tags")
   BlogResponseDto toResponse(Blog blog, List<String> tags);
+
+  @Mapping(target = "blogId", source = "id")
+  @Mapping(target = "memberId", source = "member.id")
+  @Mapping(target = "tags", expression = "java(blog.getTagNames())")
+  BlogResponseDto toResponse(Blog blog);
+
+
+  List<BlogResponseDto> toResponseList(List<Blog> blogs);
+
+//  @AfterMapping
+//  default void mapTags(Blog blog, @MappingTarget BlogResponseDto.BlogResponseDtoBuilder responseBuilder) {
+//    List<String> tagNames = blog.getBlogTags().stream()
+//        .map(blogTag -> blogTag.getTag().getName())
+//        .toList();
+//
+//    responseBuilder.tags(tagNames);
+//  }
 }

--- a/src/test/java/com/example/PostgresContainerTest.java
+++ b/src/test/java/com/example/PostgresContainerTest.java
@@ -1,0 +1,30 @@
+package com.example;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ExtendWith(SpringExtension.class)
+public class PostgresContainerTest {
+  // 테스트 전반에서 단 한 번만 재사용되는 컨테이너
+  @Container
+  protected static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:15-alpine")
+          .withDatabaseName("testdb")
+          .withUsername("test")
+          .withPassword("test");
+
+  @DynamicPropertySource
+  static void registerProps(DynamicPropertyRegistry r) {
+    r.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+    r.add("spring.datasource.username", POSTGRES::getUsername);
+    r.add("spring.datasource.password", POSTGRES::getPassword);
+    r.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    r.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+  }
+}

--- a/src/test/java/com/example/QuerydslTestConfig.java
+++ b/src/test/java/com/example/QuerydslTestConfig.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QuerydslTestConfig {
+  @PersistenceContext
+  private EntityManager em;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(em);
+  }
+}

--- a/src/test/java/com/example/TestEntityFactory.java
+++ b/src/test/java/com/example/TestEntityFactory.java
@@ -1,8 +1,14 @@
 package com.example;
 
 import com.example.blog.common.enumerated.MemberStatus;
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog.entity.BlogVisibility;
+import com.example.blog.domain.blog_stat.entity.BlogStat;
+import com.example.blog.domain.blog_tag.entity.BlogTag;
 import com.example.blog.domain.member.entity.Member;
 import com.example.blog.domain.member.entity.MemberRole;
+import com.example.blog.domain.tag.entity.Tag;
+import jakarta.persistence.EntityManager;
 import java.util.UUID;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -13,5 +19,66 @@ public class TestEntityFactory {
     ReflectionTestUtils.setField(ret, "id", UUID.randomUUID());
     return ret;
   }
+
+  public static Member member(EntityManager em, String emailSuffix) {
+    Member m = new Member(
+        "test" + emailSuffix + "@test.com",
+        "pwd",
+        "nickname",
+        null, null, null, null,
+        "tester",
+        MemberRole.USER
+    );
+    em.persist(m);
+    return m;
+  }
+
+  public static Blog blog(EntityManager em, Member owner, String slug, String title, String desc) {
+    Blog b = new Blog(owner, title, desc, BlogVisibility.PUBLIC, slug, null);
+    em.persist(b);
+    return b;
+  }
+
+  public static Tag tag(EntityManager em, String name) {
+    Tag t = new Tag(name);
+    em.persist(t);
+    return t;
+  }
+
+  public static BlogTag link(EntityManager em, Blog blog, Tag tag) {
+    BlogTag bt = new BlogTag(blog, tag);
+    em.persist(bt);
+    return bt;
+  }
+
+  public static BlogStat stat(EntityManager em, Blog blog, long posts, long views, long followers) {
+    BlogStat s = new BlogStat(
+        blog.getId(),
+        blog,
+        posts,
+        views,
+        followers,
+        null,
+        null
+    );
+    em.persist(s);
+    return s;
+  }
+
+  /**
+   * i 값에 비례하는 메트릭을 넣어 일관적인 정렬 검증을 가능하게 함.
+   * posts = i*5, views = i*10, followers = i*2
+   */
+  public static Blog seedBlogBundle(EntityManager em, Member owner, int i) {
+    String slug = "slug-" + i;
+    Blog blog = blog(em, owner, slug, "title-" + i, "desc-" + i);
+
+    stat(em, blog, i * 5L, i * 10L, i * 2L);
+    Tag tag = tag(em, "tag-" + i);
+    link(em, blog, tag);
+
+    return blog;
+  }
+
 
 }

--- a/src/test/java/com/example/blog/BlogApplicationTests.java
+++ b/src/test/java/com/example/blog/BlogApplicationTests.java
@@ -1,13 +1,13 @@
 package com.example.blog;
 
-import org.assertj.core.api.Assertions;
+import com.example.PostgresContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class BlogApplicationTests {
+class BlogApplicationTests extends PostgresContainerTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/example/blog/domain/blog/BlogFacadeImplTest.java
+++ b/src/test/java/com/example/blog/domain/blog/BlogFacadeImplTest.java
@@ -1,0 +1,130 @@
+package com.example.blog.domain.blog;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.example.blog.auth.user_details.CustomPrincipal;
+import com.example.blog.common.pagenation.Direction;
+import com.example.blog.common.pagenation.PageInfo;
+import com.example.blog.common.pagenation.PaginatedResponse;
+import com.example.blog.common.pagenation.SortBy;
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
+import com.example.blog.domain.blog.dto.BlogResponseDto;
+import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog.entity.BlogVisibility;
+import com.example.blog.domain.blog.facade.BlogFacadeImpl;
+import com.example.blog.domain.blog.service.BlogService;
+import com.example.blog.domain.blog_stat.entity.BlogStat;
+import com.example.blog.domain.blog_stat.service.BlogStatService;
+import com.example.blog.domain.member.entity.Member;
+import com.example.blog.domain.member.service.MemberService;
+import com.example.blog.domain.tag.entity.Tag;
+import com.example.blog.domain.tag.service.TagService;
+import com.example.blog.mapper.BlogMapper;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BlogFacadeImplTest {
+
+
+  @Mock private BlogService blogService;
+  @Mock private TagService tagService;
+  @Mock private BlogStatService blogStatService;
+  @Mock private BlogMapper blogMapper;
+  @Mock private MemberService memberService;
+  @InjectMocks private BlogFacadeImpl blogFacade;
+
+  private CreateBlogRequestDto createBlogRequestDto;
+  private CustomPrincipal customPrincipal;
+  private Blog blog;
+  private List<Tag> tags;
+  private BlogResponseDto blogResponseDto;
+private UUID memberId;
+  @BeforeEach
+  void setUp(){
+    memberId = UUID.randomUUID();
+    createBlogRequestDto = new CreateBlogRequestDto(
+        "title",
+        List.of("tag1","tag2"),
+        "description",
+        "slug",
+        BlogVisibility.PUBLIC
+    );
+    customPrincipal = new CustomPrincipal(memberId, "email", "USER", "ACTIVE" );
+    blog = mock(Blog.class);
+    tags = List.of(new Tag("tag1"), new Tag("tag2"));
+    blogResponseDto = new BlogResponseDto(
+        UUID.randomUUID(),
+        memberId,
+        createBlogRequestDto.title(),
+        createBlogRequestDto.tags(),
+        createBlogRequestDto.description(),
+        createBlogRequestDto.visibility(),
+        createBlogRequestDto.slug(),
+        Instant.now(),
+        Instant.now()
+    );
+  }
+
+  @Test
+  @DisplayName("블로그 생성 오케스트레이션 정상 동작")
+  void 블로그_생성_오케스트레이션_정상_동작(){
+    // given
+    given(blogService.createBlog(createBlogRequestDto, customPrincipal))
+        .willReturn(blog);
+    given(tagService.getOrCreateTags(createBlogRequestDto.tags()))
+        .willReturn(tags);
+    given(blogService.saveBlog(blog)).willReturn(blog);
+    given(blogStatService.createBlogStat(blog)).willReturn(mock(BlogStat.class));
+    given(blogMapper.toResponse(blog))
+        .willReturn(blogResponseDto);
+
+    //when
+    BlogResponseDto res = blogFacade.createBlog(createBlogRequestDto, customPrincipal);
+
+    //then
+    verify(blogService).createBlog(createBlogRequestDto, customPrincipal);
+    verify(tagService).getOrCreateTags(createBlogRequestDto.tags());
+    verify(blogService).addTags(tags, blog);
+    verify(blogService).saveBlog(blog);
+    verify(blogStatService).createBlogStat(blog);
+    verify(blogMapper).toResponse(blog);
+  }
+
+  @Test
+  @DisplayName("멤버 검증 후 블로그 목록 조회 성공")
+  void 멤버_검증_수_블로그_목록_조회_성공(){
+    BlogPaginationRequest req = new BlogPaginationRequest(
+        SortBy.FOLLOWERS, Direction.DESC, 10, null
+    );
+    PaginatedResponse<BlogResponseDto> expected = new PaginatedResponse<>(List.of(blogResponseDto), new PageInfo(1, 10, 0, blogResponseDto.blogId(), false));
+
+    given(memberService.findMemberById(memberId))
+        .willReturn(mock(Member.class));
+    given(blogService.getMemberBlogs(memberId, req)).willReturn(expected);
+
+    // when
+    PaginatedResponse<BlogResponseDto> result =
+        blogFacade.getMemberBlogs(memberId, req);
+
+    // then
+    Assertions.assertThat(result).isEqualTo(expected);
+
+    verify(memberService).findMemberById(memberId);
+    verify(blogService).getMemberBlogs(memberId, req);
+    verifyNoMoreInteractions(blogService, tagService, blogStatService, blogMapper, memberService);
+  }
+}

--- a/src/test/java/com/example/blog/domain/blog/BlogServiceImplTest.java
+++ b/src/test/java/com/example/blog/domain/blog/BlogServiceImplTest.java
@@ -2,7 +2,6 @@ package com.example.blog.domain.blog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -11,7 +10,6 @@ import com.example.TestEntityFactory;
 import com.example.blog.auth.user_details.CustomPrincipal;
 import com.example.blog.common.exception.BlogException;
 import com.example.blog.common.exception.MemberException;
-import com.example.blog.domain.blog.dto.BlogResponseDto;
 import com.example.blog.domain.blog.dto.CreateBlogRequestDto;
 import com.example.blog.domain.blog.entity.Blog;
 import com.example.blog.domain.blog.entity.BlogVisibility;
@@ -61,7 +59,7 @@ public class BlogServiceImplTest {
         "slug",
         BlogVisibility.PUBLIC
     );
-    blogService = new BlogServiceImpl(memberPort, blogPort, blogMapper, tagService, blogTagRepository, blogStatService);
+    blogService = new BlogServiceImpl(memberPort, blogPort, blogMapper);
   }
 
   @Test
@@ -76,10 +74,10 @@ public class BlogServiceImplTest {
     given(memberPort.findById(randomId)).willReturn(Optional.of(member));
 
     Tag tag = new Tag(requestDto.tags().get(0));
-    given(tagService.getOrCreateTags(requestDto.tags())).willReturn(List.of(tag));
+//    given(tagService.getOrCreateTags(requestDto.tags())).willReturn(List.of(tag));
 
     Blog blogEntity = mock(Blog.class);
-    given(blogPort.save(any(Blog.class))).willAnswer(invocation -> invocation.getArgument(0));
+//    given(blogPort.save(any(Blog.class))).willAnswer(invocation -> invocation.getArgument(0));
 
     // when
     Blog result = blogService.createBlog(requestDto, principal);

--- a/src/test/java/com/example/blog/domain/blog/BlogServiceImplTest.java
+++ b/src/test/java/com/example/blog/domain/blog/BlogServiceImplTest.java
@@ -17,6 +17,8 @@ import com.example.blog.domain.blog.entity.Blog;
 import com.example.blog.domain.blog.entity.BlogVisibility;
 import com.example.blog.domain.blog.respository.BlogRepositoryPort;
 import com.example.blog.domain.blog.service.BlogServiceImpl;
+import com.example.blog.domain.blog_stat.service.BlogStatService;
+import com.example.blog.domain.blog_tag.repository.BlogTagRepository;
 import com.example.blog.domain.member.entity.Member;
 import com.example.blog.domain.member.repository.MemberRepositoryPort;
 import com.example.blog.domain.tag.entity.Tag;
@@ -40,6 +42,8 @@ public class BlogServiceImplTest {
   @Mock private BlogRepositoryPort blogPort;
   private BlogMapper blogMapper = new BlogMapperImpl();
   @Mock private TagService tagService;
+  @Mock private BlogTagRepository blogTagRepository;
+  @Mock   private BlogStatService blogStatService;
 
   private BlogServiceImpl blogService;
 
@@ -57,7 +61,7 @@ public class BlogServiceImplTest {
         "slug",
         BlogVisibility.PUBLIC
     );
-    blogService = new BlogServiceImpl(memberPort, blogPort, blogMapper, tagService);
+    blogService = new BlogServiceImpl(memberPort, blogPort, blogMapper, tagService, blogTagRepository, blogStatService);
   }
 
   @Test
@@ -78,13 +82,13 @@ public class BlogServiceImplTest {
     given(blogPort.save(any(Blog.class))).willAnswer(invocation -> invocation.getArgument(0));
 
     // when
-    BlogResponseDto result = blogService.createBlog(requestDto, principal);
+    Blog result = blogService.createBlog(requestDto, principal);
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result.title()).isEqualTo("title");
-    assertThat(result.slug()).isEqualTo("slug");
-    assertThat(result.tags()).containsExactly("tag1");
+    assertThat(result.getTitle()).isEqualTo("title");
+    assertThat(result.getSlug()).isEqualTo("slug");
+//    assertThat(result.tags()).containsExactly("tag1");
   }
 
   @Test

--- a/src/test/java/com/example/blog/domain/blog/repository/BlogQueryRepositoryTest.java
+++ b/src/test/java/com/example/blog/domain/blog/repository/BlogQueryRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.example.blog.domain.blog.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.PostgresContainerTest;
+import com.example.QuerydslTestConfig;
+import com.example.TestEntityFactory;
+import com.example.blog.common.pagenation.Direction;
+import com.example.blog.common.pagenation.SortBy;
+import com.example.blog.domain.blog.dto.BlogPaginationRequest;
+import com.example.blog.domain.blog.entity.Blog;
+import com.example.blog.domain.blog.respository.BlogQueryRepositoryImpl;
+import com.example.blog.domain.member.entity.Member;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+
+@DataJpaTest
+@Import({QuerydslTestConfig.class})
+@ActiveProfiles("test")
+class BlogQueryRepositoryImplTest extends PostgresContainerTest {
+  @Autowired
+  private BlogQueryRepositoryImpl blogQueryRepository;
+  @PersistenceContext
+  private EntityManager em;
+
+  private Member member;
+
+  @BeforeEach
+  void setUp() {
+    member = TestEntityFactory.member(em, "1");
+    IntStream.range(0, 3).forEach(i -> TestEntityFactory.seedBlogBundle(em, member, i));
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("viewCount DESC 정렬")
+  void findByMemberIdAndQuery_viewCount_desc() {
+    BlogPaginationRequest request = new BlogPaginationRequest(SortBy.VIEWS, Direction.DESC, 10, null);
+
+    List<Blog> result = blogQueryRepository.findByMemberIdAndQuery(member.getId(), request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result).extracting(Blog::getSlug)
+        .containsExactly("slug-2", "slug-1", "slug-0");
+  }
+
+  @Test
+  @DisplayName("followerCount ASC 정렬")
+  void findByMemberIdAndQuery_followerCount_asc() {
+    BlogPaginationRequest request = new BlogPaginationRequest(SortBy.FOLLOWERS, Direction.ASC, 10, null);
+
+    List<Blog> result = blogQueryRepository.findByMemberIdAndQuery(member.getId(), request);
+
+    assertThat(result).hasSize(3);
+    assertThat(result).extracting(Blog::getSlug)
+        .containsExactly("slug-0", "slug-1", "slug-2");
+  }
+
+  @Test
+  @DisplayName("postCount DESC 정렬 + limit+1 적용 확인")
+  void findByMemberIdAndQuery_postCount_desc_limitPlusOne() {
+    BlogPaginationRequest request = new BlogPaginationRequest(SortBy.POSTS, Direction.DESC, 2, null);
+
+    List<Blog> result = blogQueryRepository.findByMemberIdAndQuery(member.getId(), request);
+
+    assertThat(result).hasSize(3); // limit=2이지만 내부 fetch는 3 (= limit+1)
+    assertThat(result).extracting(Blog::getSlug)
+        .containsExactly("slug-2", "slug-1", "slug-0");
+  }
+
+}

--- a/src/test/java/com/example/blog/domain/blog/repository/BlogQueryRepositoryTest.java
+++ b/src/test/java/com/example/blog/domain/blog/repository/BlogQueryRepositoryTest.java
@@ -70,13 +70,13 @@ class BlogQueryRepositoryImplTest extends PostgresContainerTest {
   @Test
   @DisplayName("postCount DESC 정렬 + limit+1 적용 확인")
   void findByMemberIdAndQuery_postCount_desc_limitPlusOne() {
-    BlogPaginationRequest request = new BlogPaginationRequest(SortBy.POSTS, Direction.DESC, 2, null);
+    BlogPaginationRequest request = new BlogPaginationRequest(SortBy.POSTS, Direction.DESC, 1, null);
 
     List<Blog> result = blogQueryRepository.findByMemberIdAndQuery(member.getId(), request);
 
-    assertThat(result).hasSize(3); // limit=2이지만 내부 fetch는 3 (= limit+1)
+    assertThat(result).hasSize(2); // limit=2이지만 내부 fetch는 3 (= limit+1)
     assertThat(result).extracting(Blog::getSlug)
-        .containsExactly("slug-2", "slug-1", "slug-0");
+        .containsExactly("slug-2", "slug-1");
   }
 
 }

--- a/src/test/java/com/example/blog/domain/tag/TagServiceTest.java
+++ b/src/test/java/com/example/blog/domain/tag/TagServiceTest.java
@@ -1,0 +1,66 @@
+package com.example.blog.domain.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.blog.domain.tag.entity.Tag;
+import com.example.blog.domain.tag.repository.TagRepository;
+import com.example.blog.domain.tag.service.TagServiceImpl;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TagServiceTest {
+  @Mock
+  TagRepository tagRepository;
+
+  @InjectMocks
+  TagServiceImpl tagService;
+  @Captor
+  ArgumentCaptor<List<Tag>> tagListCaptor;
+
+  @BeforeEach
+  void setUp(){
+
+  }
+
+
+  @Test
+  @DisplayName("테그를 불러오거나 생성할 수 있다")
+  void 테그를_불러오거나_생성할_수_있다(){
+    // given
+    List<String> req = List.of("tag1", "tag2");
+    given(tagRepository.findAllByNameIn(req)).willReturn(Set.of(new Tag("tag1")));
+    given(tagRepository.saveAll(tagListCaptor.capture()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    //when
+    List<Tag> result = tagService.getOrCreateTags(req);
+
+    //then
+    List<Tag> captured = tagListCaptor.getValue();
+
+    assertThat(captured).hasSize(1);
+    assertThat(captured.get(0).getName()).isEqualTo("tag2");
+
+    // 최종 결과에는 기존 tag1과 새로 저장된 tag2가 모두 포함되어야 함
+    assertThat(result.stream().map(Tag::getName).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder("tag1", "tag2");
+
+    // saveAll 호출 검증
+    verify(tagRepository).saveAll(captured);
+
+  }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,11 +2,6 @@ spring:
   sql:
     init:
       mode: never
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1
-    driverClassName: org.h2.Driver
-    username: sa
-    password:
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public endpoint GET /api/member/{memberId}/blogs for listing a member’s blogs.
  - Cursor-based paginated responses with page metadata and sorting by views, posts, or followers; sort and direction accept case-insensitive values.
  - Blog responses include tag names and a builder-based response DTO.

- Refactor
  - Blog API base path changed to /api.

- Chores
  - Upgraded QueryDSL to Jakarta 5.1.0 and added Jakarta annotation processors.
  - Added Testcontainers PostgreSQL support and related test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->